### PR TITLE
Fix release body invalid link issue

### DIFF
--- a/.github/workflows/OrangeFox-Compile.yml
+++ b/.github/workflows/OrangeFox-Compile.yml
@@ -102,6 +102,12 @@ jobs:
         echo "BUILD_DATE=$(TZ=Asia/Manila date +%Y%m%d)" >> $GITHUB_ENV
         cd ${GITHUB_WORKSPACE}/OrangeFox/fox_${{ inputs.MANIFEST_BRANCH }}
 
+        DEVICE_TREE_URL="${{ inputs.DEVICE_TREE }}"
+        if [[ "${DEVICE_TREE_URL}" == *.git ]]; then
+          DEVICE_TREE_URL="${DEVICE_TREE_URL%.git}"
+        fi
+        echo "DEVICE_TREE_URL=${DEVICE_TREE_URL}" >> $GITHUB_ENV
+
     - name: Upload to Release
       uses: softprops/action-gh-release@v2
       with:
@@ -113,5 +119,6 @@ jobs:
         body: |
           ## OrangeFox Recovery Build - Unofficial
           Build: fox_${{ inputs.MANIFEST_BRANCH }}
-          Device: [Device Tree/Branch](${{ inputs.DEVICE_TREE }}/tree/${{ inputs.DEVICE_TREE_BRANCH }})
-          Commit: Most recent [commit](${{ inputs.DEVICE_TREE }}/commit/${{ env.COMMIT_ID }}) during building.
+          Device: [Device Tree/Branch](${{ env.DEVICE_TREE_URL }}/tree/${{ inputs.DEVICE_TREE_BRANCH }})
+          Commit: Most recent [commit](${{ env.DEVICE_TREE_URL }}/commit/${{ env.COMMIT_ID }}) during building.
+          


### PR DESCRIPTION
Most of the git hosting platforms provides .git extension for the repo url in their "copy clone url" option.

There's an issue in release body where if the url ends with .git extension, the link will become invalid because the output of release body would be like this:

https://gthub.com/user/device_tree.git/tree/main
instead of
https://gthub.com/user/device_tree/tree/main

This will check if the device tree url ends with .git, if it does, it will be removed before passing it on release body